### PR TITLE
[TASK]: Instituciones Top 10 #1 - Implementar endpoint GET /api/tableros/instituciones/top10/

### DIFF
--- a/apps/consultas/application/selectors/institutions_top10_queries.py
+++ b/apps/consultas/application/selectors/institutions_top10_queries.py
@@ -1,0 +1,9 @@
+from typing import List, Dict
+from apps.consultas.infrastructure.repositories.institutions_repo import get_top10_instituciones
+
+def instituciones_top10() -> List[Dict]:
+    """
+    Retorna a lo sumo 10 instituciones, ordenadas desc por total.
+    """
+    data = get_top10_instituciones()
+    return sorted(data, key=lambda d: d.get("total", 0), reverse=True)[:10]

--- a/apps/consultas/infrastructure/repositories/institutions_repo.py
+++ b/apps/consultas/infrastructure/repositories/institutions_repo.py
@@ -1,0 +1,17 @@
+from typing import List, Dict
+from django.db import connection
+
+def get_top10_instituciones() -> List[Dict]:
+    """
+    Llama a la función Postgres f_cuenta_registros_por_institucion_top10()
+    y retorna una lista de dicts con keys:
+    id_institucion, institucion_nombre, total
+    """
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            select id_institucion, institucion_nombre, total
+            from f_cuenta_registros_por_institucion_top10()
+        """)
+        cols = [c[0] for c in cursor.description]
+        rows = cursor.fetchall()
+    return [dict(zip(cols, r)) for r in rows]

--- a/apps/consultas/infrastructure/web/serializer.py
+++ b/apps/consultas/infrastructure/web/serializer.py
@@ -12,3 +12,8 @@ class StatusCountSerializer(serializers.Serializer):
 class CategoriaInvestigadorSerializer(serializers.Serializer):
     categoria = serializers.CharField()
     total = serializers.IntegerField()
+
+class InstitucionTopSerializer(serializers.Serializer):
+    id_institucion = serializers.IntegerField()
+    institucion_nombre = serializers.CharField()
+    total = serializers.IntegerField()

--- a/apps/consultas/infrastructure/web/urls.py
+++ b/apps/consultas/infrastructure/web/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('tableros/entidades/top10/', ConsultaViewSet.as_view({'get': 'entidades_top10_view'}), name='entidades-top10'),
     path('tableros/registros/estatus/', ConsultaViewSet.as_view({'get': 'records_by_status_view'}), name='registros-por-estatus'),
     path('tableros/investigadores/categorias/', ConsultaViewSet.as_view({'get': 'categoria_investigadores_view'}), name='categoria-investigadores'),
+    path('tableros/instituciones/top10/', ConsultaViewSet.as_view({'get': 'instituciones_top10_view'}), name='instituciones-top10'),
 
     
     path("", include(router.urls)),

--- a/apps/consultas/infrastructure/web/views.py
+++ b/apps/consultas/infrastructure/web/views.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from rest_framework.decorators import action
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 
+from apps.consultas.application.selectors.institutions_top10_queries import instituciones_top10
 from apps.consultas.application.selectors.category_researchers import conteo_investigadores_por_categoria_selector
 from apps.consultas.application.selectors.federal_entities_top10_queries import entidades_top10
 from apps.consultas.application.selectors.records_by_status import conteo_registros_por_estatus_selector
@@ -10,6 +11,7 @@ from apps.consultas.infrastructure.web.serializer import (
     EntidadTopSerializer,
     StatusCountSerializer,
     CategoriaInvestigadorSerializer,
+    InstitucionTopSerializer,
 )
 from rest_framework.permissions import AllowAny
 
@@ -51,3 +53,11 @@ class ConsultaViewSet(viewsets.ViewSet):
         summary="registros agrupados por tipo de investigador (Docente, Alumno, Administrativo)",
         responses={200: CategoriaInvestigadorSerializer(many=True)},
 
+    @extend_schema(
+        summary="Top 10 instituciones por número de registros",
+        responses={200: InstitucionTopSerializer(many=True)},
+    )
+    @action(detail=False, methods=["get"])
+    def instituciones_top10_view(self, request):
+        resultado = instituciones_top10()
+        return Response(resultado, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Resumen
Crear endpoint para mostrar las 10 instituciones con más registros.

## Tarea
Implementar un endpoint REST en Django siguiendo Clean Architecture.
Llamar a la función Postgres f_cuenta_registros_por_institucion_top10().
Endpoint: GET /api/tableros/instituciones/top10/

## Evidencia
<img width="783" height="572" alt="image" src="https://github.com/user-attachments/assets/4b27a533-ca7a-4273-9343-2ca9e214fcbf" />
<img width="799" height="379" alt="image" src="https://github.com/user-attachments/assets/e1129806-8ad3-4847-bfcc-0f4a98abc325" />
