### PR TITLE
feat: Endpoint para registros agrupados por sector económico

### DIFF
--- a/apps/consultas/application/selectors/economic_sectors_queries.py
+++ b/apps/consultas/application/selectors/economic_sectors_queries.py
@@ -1,0 +1,9 @@
+from typing import List, Dict
+from apps.consultas.infrastructure.repositories.economic_sectors_repo import EconomicSectorsRepository
+
+def conteo_registros_por_sector_selector() -> List[Dict]:
+    """
+    Selector que obtiene el conteo de registros agrupados por sector económico.
+    """
+    repository = EconomicSectorsRepository()
+    return repository.obtener_conteo_por_sector()

--- a/apps/consultas/infrastructure/repositories/economic_sectors_repo.py
+++ b/apps/consultas/infrastructure/repositories/economic_sectors_repo.py
@@ -1,0 +1,32 @@
+from typing import List, Dict
+from django.db import connection
+
+class EconomicSectorsRepository:
+    """ 
+    Repositorio para obtener conteo de registros por sector económico.
+    """
+
+    def obtener_conteo_por_sector(self) -> List[Dict]:
+        """
+        Llama a la función Postgres f_cuenta_registros_por_sectores(),
+        la une con la tabla parametrización para obtener los nombres legibles
+        y ordena el resultado por el total de forma descendente. 
+        """
+        query = """ 
+            SELECT
+                p.nombre AS sector,
+                t.total
+            FROM
+                f_cuenta_registros_por_sectores() AS t
+            INNER JOIN
+                parametrizacion AS p ON t.tipo_sector_param = p.id_param
+            ORDER BY
+                t.total DESC;
+        """
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            cols = [c[0] for c in cursor.description]
+            return [
+                dict(zip(cols, r)) 
+                for r in cursor.fetchall()
+            ]

--- a/apps/consultas/infrastructure/web/serializer.py
+++ b/apps/consultas/infrastructure/web/serializer.py
@@ -17,3 +17,7 @@ class InstitucionTopSerializer(serializers.Serializer):
     id_institucion = serializers.IntegerField()
     institucion_nombre = serializers.CharField()
     total = serializers.IntegerField()
+
+class SectorEconomicoSerializer(serializers.Serializer):
+    sector = serializers.CharField()
+    total = serializers.IntegerField()

--- a/apps/consultas/infrastructure/web/urls.py
+++ b/apps/consultas/infrastructure/web/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path('registros/estatus/', ConsultaViewSet.as_view({'get': 'records_by_status_view'}), name='registros-por-estatus'),
     path('investigadores/categorias/', ConsultaViewSet.as_view({'get': 'categoria_investigadores_view'}), name='categoria-investigadores'),
     path('instituciones/top10/', ConsultaViewSet.as_view({'get': 'instituciones_top10_view'}), name='instituciones-top10'),
+    path('sectores/', ConsultaViewSet.as_view({'get': 'registros_por_sector_view'}), name='registros-por-sector'),
 ]

--- a/apps/consultas/infrastructure/web/views.py
+++ b/apps/consultas/infrastructure/web/views.py
@@ -7,11 +7,13 @@ from apps.consultas.application.selectors.institutions_top10_queries import inst
 from apps.consultas.application.selectors.category_researchers import conteo_investigadores_por_categoria_selector
 from apps.consultas.application.selectors.federal_entities_top10_queries import entidades_top10
 from apps.consultas.application.selectors.records_by_status import conteo_registros_por_estatus_selector
+from apps.consultas.application.selectors.economic_sectors_queries import conteo_registros_por_sector_selector
 from apps.consultas.infrastructure.web.serializer import (
     EntidadTopSerializer,
     StatusCountSerializer,
     CategoriaInvestigadorSerializer,
     InstitucionTopSerializer,
+    SectorEconomicoSerializer,
 )
 from rest_framework.permissions import AllowAny
 
@@ -60,4 +62,13 @@ class ConsultaViewSet(viewsets.ViewSet):
     @action(detail=False, methods=["get"])
     def instituciones_top10_view(self, request):
         resultado = instituciones_top10()
+        return Response(resultado, status=status.HTTP_200_OK)
+    
+    @extend_schema(
+        summary="Registros agrupados por sector económico",
+        responses={200: SectorEconomicoSerializer(many=True)},
+    )
+    @action(detail=False, methods=["get"])
+    def registros_por_sector_view(self, request):
+        resultado = conteo_registros_por_sector_selector()
         return Response(resultado, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Descripción
Implementa endpoint GET `/api/tableros/sectores/` que retorna registros agrupados por sector económico.

## Cambios realizados
- Creado repositorio `economic_sectors_repo.py`
- Creado selector `economic_sectors_queries.py`
- Agregado serializer `SectorEconomicoSerializer`
- Agregado método `registros_por_sector_view`
- Agregada ruta `/api/tableros/sectores/`

## Issue relacionado
Closes  #3 