### PR TITLE
feat: agregar endpoint sectores por actividad

### DIFF
--- a/apps/consultas/application/selectors/sectors_activity_queries.py
+++ b/apps/consultas/application/selectors/sectors_activity_queries.py
@@ -1,0 +1,10 @@
+from typing import List, Dict
+from apps.consultas.infrastructure.repositories.sectors_activity_repo import get_sectores_por_actividad
+
+
+def sectores_actividad_top10() -> List[Dict]:
+    """
+    Retorna a lo sumo 10 sectores, ordenados desc por total.
+    """
+    data = get_sectores_por_actividad()
+    return sorted(data, key=lambda d: d.get("total", 0), reverse=True)[:10]

--- a/apps/consultas/infrastructure/repositories/sectors_activity_repo.py
+++ b/apps/consultas/infrastructure/repositories/sectors_activity_repo.py
@@ -1,0 +1,18 @@
+from typing import List, Dict
+from django.db import connection
+
+
+def get_sectores_por_actividad() -> List[Dict]:
+    """
+    Llama a la función Postgres f_cuenta_registros_por_actividad()
+    y retorna una lista de dicts con keys:
+    tipo_sector_param, sector_nombre, total
+    """
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            SELECT tipo_sector_param, sector_nombre, total
+            FROM f_cuenta_registros_por_actividad()
+        """)
+        cols = [c[0] for c in cursor.description]
+        rows = cursor.fetchall()
+    return [dict(zip(cols, r)) for r in rows]

--- a/apps/consultas/infrastructure/web/serializer.py
+++ b/apps/consultas/infrastructure/web/serializer.py
@@ -29,3 +29,8 @@ class RegistrosPorSexoSerializer(serializers.Serializer):
 class RequestTypeSerializer(serializers.Serializer):
     type = serializers.CharField()
     total = serializers.IntegerField()
+
+class SectorActividadSerializer(serializers.Serializer):
+    tipo_sector_param = serializers.IntegerField()
+    sector_nombre = serializers.CharField()
+    total = serializers.IntegerField()

--- a/apps/consultas/infrastructure/web/urls.py
+++ b/apps/consultas/infrastructure/web/urls.py
@@ -17,6 +17,8 @@ urlpatterns = [
     path('solicitudes/indautor/', ConsultaViewSet.as_view({'get': 'requests_indautor_view'}), name='requests-indautor'),
     path('instituciones/all/', ConsultaViewSet.as_view({'get': 'instituciones_all_view'}), name='instituciones-all'),
     path('entidades/all/', ConsultaViewSet.as_view({'get': 'entidades_all_view'}), name='entidades-all'),
+    path('sectores/actividad/', ConsultaViewSet.as_view({'get': 'sectores_actividad_view'}), name='sectores-actividad'),
+
 
 
 ]

--- a/apps/consultas/infrastructure/web/views.py
+++ b/apps/consultas/infrastructure/web/views.py
@@ -12,6 +12,7 @@ from apps.consultas.application.selectors.economic_sectors_queries import conteo
 from apps.consultas.application.selectors.records_by_sex_queries import registros_por_sexo_selector
 from apps.consultas.application.selectors.institutions_all_queries import instituciones_all
 from apps.consultas.application.selectors.federal_entities_all_queries import entidades_all
+from apps.consultas.application.selectors.sectors_activity_queries import sectores_actividad_top10 
 from apps.consultas.infrastructure.web.serializer import (
     EntidadTopSerializer,
     StatusCountSerializer,
@@ -19,7 +20,9 @@ from apps.consultas.infrastructure.web.serializer import (
     InstitucionTopSerializer,
     SectorEconomicoSerializer,
     RegistrosPorSexoSerializer,
-    RequestTypeSerializer
+    RequestTypeSerializer,
+    SectorActividadSerializer 
+
 )
 from rest_framework.permissions import AllowAny
 
@@ -122,4 +125,16 @@ class ConsultaViewSet(viewsets.ViewSet):
     @action(detail=False, methods=["get"])
     def entidades_all_view(self, request):
         resultado = entidades_all()
+        return Response(resultado, status=status.HTTP_200_OK)
+    
+    @extend_schema(
+        summary="Top 10 registros agrupados por sector/actividad económica",
+        responses={200: SectorActividadSerializer(many=True)},
+    )
+    @action(detail=False, methods=["get"])
+    def sectores_actividad_view(self, request):
+        """
+        Endpoint para obtener el top 10 de sectores por actividad económica.
+        """
+        resultado = sectores_actividad_top10()
         return Response(resultado, status=status.HTTP_200_OK)


### PR DESCRIPTION
# Qué
Implementar endpoint GET /api/tableros/sectores/actividad/ que retorna el top 10 de sectores económicos agrupados por cantidad de registros.

# Cómo
- Repository: sectores_actividad_repo.py (llamada a función Postgres)
- Selector: sectores_actividad_selector.py (lógica de ordenamiento y top 10)
- Serializer: SectorActividadSerializer (validación JSON)
- View: @action sectores_actividad_view (endpoint REST)
- URL: path('sectores/actividad/', ...)